### PR TITLE
This stops the errors that are within the standard Qbox recipe

### DIFF
--- a/client/camera.lua
+++ b/client/camera.lua
@@ -136,6 +136,7 @@ end)
 
 CreateThread(function()
 	while true do
+		if not isLoggedIn then return end
 		if QBX.PlayerData.job.name == 'reporter' then
 			if holdingCam then
 				lib.requestAnimDict(camanimDict)
@@ -165,6 +166,7 @@ end)
 
 CreateThread(function()
 	while true do
+		if not isLoggedIn then return end
 		if QBX.PlayerData.job.name == 'reporter' then
 			if holdingCam then
 				if IsControlJustReleased(1, 244) then
@@ -243,6 +245,7 @@ end)
 
 CreateThread(function()
 	while true do
+		if not isLoggedIn then Wait (1000) return end
 		if QBX.PlayerData.job.name == 'reporter' then
 			if holdingCam then
 				if IsControlJustReleased(1, 38) then
@@ -340,6 +343,7 @@ end)
 
 CreateThread(function()
 	while true do
+		if not isLoggedIn then Wait (1000) return end
 		if QBX.PlayerData.job.name == 'reporter' then
 			if holdingBmic then
 				lib.requestAnimDict(bmicanimDict)

--- a/client/camera.lua
+++ b/client/camera.lua
@@ -344,7 +344,7 @@ end)
 
 CreateThread(function()
 	while true do
-		if not isLoggedIn then Wait (1000) return end
+		if not isLoggedIn then return end
 		if QBX.PlayerData.job.name == 'reporter' then
 			if holdingBmic then
 				lib.requestAnimDict(bmicanimDict)

--- a/client/camera.lua
+++ b/client/camera.lua
@@ -28,6 +28,7 @@ local new_z
 local movcamera
 local newscamera
 
+local isLoggedIn = LocalPlayer.state.isLoggedIn
 
 --FUNCTIONS--
 local function HideHUDThisFrame()

--- a/client/camera.lua
+++ b/client/camera.lua
@@ -245,7 +245,7 @@ end)
 
 CreateThread(function()
 	while true do
-		if not isLoggedIn then Wait (1000) return end
+		if not isLoggedIn then return end
 		if QBX.PlayerData.job.name == 'reporter' then
 			if holdingCam then
 				if IsControlJustReleased(1, 38) then

--- a/client/main.lua
+++ b/client/main.lua
@@ -433,8 +433,7 @@ local function init()
     registerEnterRoof()
     registerExitRoof()
 
-	if not isLoggedIn then return end
-    if QBX.PlayerData.job.name == 'reporter' then
+    if QBX.PlayerData.job.name == 'reporter' and isLoggedIn then
     registerVehicleStorage()
     registerHeliStorage()
     end

--- a/client/main.lua
+++ b/client/main.lua
@@ -433,6 +433,7 @@ local function init()
     registerEnterRoof()
     registerExitRoof()
 
+	if not isLoggedIn then return end
     if QBX.PlayerData.job.name == 'reporter' then
     registerVehicleStorage()
     registerHeliStorage()


### PR DESCRIPTION
## Description

This returns the thread while the player is not logged in to stop any errors

So basically this has a couple looped threads that check for the players job to = "reporter". Now if the player is not logged in, it can not possibly get the player's job and/or any other data.

To fix this I simply returned all the threads if the player is not logged in, now this checking every ms so it should allow the thread to continue to run properly after the player has loaded its data properly.

I am sure there are better ways to do this but this needs slight optimization at some point anyway which I am in the process of doing at the moment. I hope this gets pushed for now. Thanks Qbox <3 

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [✅ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [✅ ] My code fits the style guidelines.
- [✅ ] My PR fits the contribution guidelines.
