### PR TITLE
Update main.lua

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -34,7 +34,7 @@ lib.addCommand('newsbmic', {
 end)
 
 lib.callback.register('qbx_newsjob:server:spawnVehicle', function(source, model, coords, plate)
-    local netId, veh = qbx.spawnVehicle(source, model, coords)
+    local netId, veh = qbx.spawnVehicle({ model = model, spawnSource = coords, props = { plate = plate } })
     if not netId or netId == 0 then return end
     if not veh or veh == 0 then return end
     SetEntityHeading(veh, coords.w)


### PR DESCRIPTION
## Description

Previous qbx.spawnVehicle was causing an error when attempting to take out a car or helicopter.

Old code:

```
local netId, veh = qbx.spawnVehicle(source, model, coords)
```

Error:

```
[  script:qbx_newsjob] SCRIPT ERROR: @qbx_core/modules/lib.lua:249: attempt to index a number value (local 'params') 
[  script:qbx_newsjob] > callbackResponse (@ox_lib/imports/callback/server.lua:79) 
[  script:qbx_newsjob] > handler (@ox_lib/imports/callback/server.lua:96)
```

The new code doesn't generate this error and spawns the vehicle as expected.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
